### PR TITLE
Auto-detect a vendor directory outside of a magento root directory

### DIFF
--- a/app/code/community/Varien/Autoload.php
+++ b/app/code/community/Varien/Autoload.php
@@ -93,6 +93,8 @@ class Varien_Autoload
             return $basePath . 'lib' . DIRECTORY_SEPARATOR . $vendorDirName;
         } elseif (is_dir($basePath . $vendorDirName)) {
             return $basePath . $vendorDirName;
+        } elseif (is_dir($basePath . '..' . DIRECTORY_SEPARATOR . $vendorDirName)) {
+	        return $basePath . '..' . DIRECTORY_SEPARATOR . $vendorDirName;
         }
 
         return false;


### PR DESCRIPTION
Added common use case of a vendor directory

- magento_root_dir
---- app
-------- code
-------- design
-------- etc
-------- locale
- vendor

auto detect without environment variable or php constant.
Thanks.